### PR TITLE
Add Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Metrics are a different way to directly report numeric Metrics straight to DataD
 You can add new Metrics in the `lua/doglogs/modules/` directory. Roughly, it should look like this:
 ```lua
 DogMetrics:NewMetric( {
-    name = "gameserver.luaMemory",
+    name = "cfc.server.luaMemory", -- Suggested to prefix this with `<org>.` so you can easily search for all of your metrics on DD
     unit = "kilobyte", -- or "frame", "byte", "packet", etc.
     interval = 1, -- In seconds, how often to collect this metric
     metricType = DogMetrics.MetricTypes.Count, -- or .Rate, .Gauge

--- a/README.md
+++ b/README.md
@@ -54,3 +54,39 @@ Now, we need to make the grok parsing rule. It's probably best if you copy from 
  - You can match a section of text without actually extracting it. For example, if there was a variable number that you didn't care about, you could match it with: `%{data}` and simply not include the `name` portion
  - The Log Samples section is limited to only 5 samples, so you'll eventually have to delete old samples. It's a good idea to copy the samples and re-paste them when you're done to make sure they still work
  - There is a section that pops up below the "Define parsing rules" box - this section shows an example of what your rule will extract from the sample (**Note**: this only shows an example of the Sample you most recently clicked into)
+
+## Metrics
+Metrics are a different way to directly report numeric Metrics straight to DataDog.
+
+You can add new Metrics in the `lua/doglogs/modules/` directory. Roughly, it should look like this:
+```lua
+DogMetrics:NewMetric( {
+    name = "gameserver.luaMemory",
+    unit = "kilobyte", -- or "frame", "byte", "packet", etc.
+    interval = 1, -- In seconds, how often to collect this metric
+    metricType = DogMetrics.MetricTypes.Rate, -- or .Gauge, .Count
+    measureFunc = function()
+        -- This function gets called at the defined interval, and should return a number
+
+        return collectgarbage("count") -- already in kilobytes
+    end
+} )
+```
+
+### Metrics Configuration:
+There are a few convars you'll want to set:
+
+#### `datadog_api_key`
+Should be set to the API key created in: https://app.datadoghq.com/organization-settings/api-keys
+
+#### `datadog_hostname`
+The hostname to use for the Metric reporting. Typically this is some meta-level name for the entire machine running your game server.
+
+#### `datadog_service_name`
+Some shortcode name for the game server - should match whatever you have setup in your DataDog agent _(not strictly necessary, but it helps DD correlate info)_
+
+#### `datadog_report_interval`
+In seconds, how often to report to DataDog. I think the only things to consider here are:
+- How big will each payload get? DD imposes a size limit of 500kB per payload.
+- What is your deal with DataDog?
+  - While the endpoint isn't rate-limited, you may have limits about the quantity of custom metrics

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ DogMetrics:NewMetric( {
     name = "gameserver.luaMemory",
     unit = "kilobyte", -- or "frame", "byte", "packet", etc.
     interval = 1, -- In seconds, how often to collect this metric
-    metricType = DogMetrics.MetricTypes.Rate, -- or .Gauge, .Count
+    metricType = DogMetrics.MetricTypes.Count, -- or .Rate, .Gauge
     measureFunc = function()
         -- This function gets called at the defined interval, and should return a number
 
-        return collectgarbage("count") -- already in kilobytes
+        return collectgarbage( "count" ) -- already in kilobytes
     end
 } )
 ```

--- a/lua/doglogs/metrics.lua
+++ b/lua/doglogs/metrics.lua
@@ -18,10 +18,10 @@ DogMetrics = {
 
 --- @enum DogMetrics_MetricTypes
 DogMetrics.MetricTypes = {
-    unspecified = 0,
-    count = 1,
-    rate = 2,
-    gauge = 3
+    Unspecified = 0,
+    Count = 1,
+    Rate = 2,
+    Gauge = 3
 }
 
 --- @class DogMetrics_NewMetricParams

--- a/lua/doglogs/metrics.lua
+++ b/lua/doglogs/metrics.lua
@@ -52,6 +52,7 @@ function DogMetrics:NewMetric( struct )
             unit = unit,
             points = points,
             resources = {
+                { name = "gmod", type = "source" },
                 { name = hostname:GetString(), type = "host" },
                 { name = serviceName:GetString(), type = "service" }
             }

--- a/lua/doglogs/metrics.lua
+++ b/lua/doglogs/metrics.lua
@@ -172,6 +172,10 @@ timer.Create( "DogMetrics_Report", reportInterval:GetFloat(), 0, function()
     DogMetrics:Report()
 end )
 
+hook.Add( "ShutDown", "DogMetrics_ShutDown", function()
+    DogMetrics:Report()
+end )
+
 cvars.AddChangeCallback( "datadog_report_interval", function( _, _, newValue )
     local newInterval = tonumber( newValue )
     if not newInterval or newInterval <= 0 then

--- a/lua/doglogs/metrics.lua
+++ b/lua/doglogs/metrics.lua
@@ -1,0 +1,144 @@
+--- @class DogMetrics
+DogMetrics = {
+    reportURL = "https://api.datadoghq.com/api/v2/series",
+    reportInterval = 60,
+    trackers = {}
+}
+
+--- @enum DogMetrics_MetricTypes
+DogMetrics.MetricTypes = {
+    unspecified = 0,
+    count = 1,
+    rate = 2,
+    gauge = 3
+}
+
+--- @param name string The name of the metric
+--- @param unit string The unit of the metric (e.g., "ms", "bytes", etc.)
+--- @param interval number The interval in seconds at which the metric should be reported
+--- @param metricType DogMetrics_MetricTypes The type of the metric
+--- @param cb fun(): number Callback function that will be called with the tracker object
+--- @return DogMetrics_Tracker The tracker object that can be used to add points to the metric
+function DogMetrics:NewMetric( name, unit, interval, metricType, cb )
+    local points = {}
+
+    --- @class DogMetrics_Tracker
+    local tracker = {
+        payload = {
+            interval = interval,
+            metric = name,
+            type = metricType,
+            unit = unit,
+            points = points,
+            resources = {
+                { name = "Dev", type = "host" },
+                { name = "cfcdev", type = "service" }
+            }
+        }
+    }
+
+    --- Adds a point to the tracker's timeseries
+    --- @param value number The value to add to the timeseries
+    function tracker:AddPoint( value )
+        table.insert( points, {
+            timestamp = os.time(),
+            value = value
+        } )
+    end
+
+    --- Clears all points from the tracker
+    function tracker:ClearPoints()
+        points = {}
+        self.payload.points = points
+    end
+
+    local timerName = "DogMetrics_Tracker_" .. name
+
+    --- Report an error and remove the tracker from the list
+    --- @param message string The error message to report
+    local function err( message )
+        timer.Remove( timerName )
+        table.RemoveByValue( self.trackers, tracker )
+
+        error( "Error in metric '" .. name .. "': " .. message, 1 )
+    end
+
+    timer.Create( timerName, interval, 0, function()
+        local success = ProtectedCall( function()
+            local value = cb()
+
+            if not value then
+                return err( "Callback for metric '" .. name .. "' returned nil - aborting collection" )
+            end
+
+            tracker:AddPoint( value )
+        end )
+
+        if not success then
+            return err( "Failed to collect metric '" .. name .. "' - aborting collection" )
+        end
+    end )
+
+    table.insert( self.trackers, tracker )
+
+    return tracker
+end
+
+--- Returns a JSON payload suitable for reporting to the DataDog Metrics API
+function DogMetrics:GetReportPayload()
+    local payload = { series = {} }
+
+    for _, tracker in ipairs( self.trackers ) do
+        if #tracker.payload.points > 0 then
+            table.insert( payload.series, tracker.payload )
+        end
+    end
+
+    return payload
+end
+
+--- Clears all points from all trackers
+function DogMetrics:ClearTrackers()
+    for _, tracker in ipairs( self.trackers ) do
+        tracker:ClearPoints()
+    end
+end
+
+--- Reports the collected metrics to the DataDog Metrics API
+function DogMetrics:Report()
+    local payload = self:GetReportPayload()
+    local body = util.TableToJSON( payload )
+
+    local queued = HTTP( {
+        url = self.reportURL,
+        method = "POST",
+        type = "application/json",
+        timeout = 5,
+
+        body = body,
+
+        success = function( code, successBody )
+            if code ~= 202 then
+                error( "Failed to report metrics: HTTP " .. code .. " - " .. successBody )
+            end
+
+            print( "[DogLogs] Metrics reported successfully." )
+        end,
+
+        failed = function( reason )
+            error( "Failed to report metrics: HTTP " .. reason )
+        end
+    } )
+
+    for _, tracker in ipairs( self.trackers ) do
+        tracker:ClearPoints()
+    end
+
+    if not queued then
+        error( "Failed to queue metrics report - HTTP request failed" )
+    end
+end
+
+timer.Create( "DogMetrics_Report", DogMetrics.reportInterval, 0, function()
+    DogMetrics:Report()
+end )

--- a/lua/doglogs/modules/server_fps.lua
+++ b/lua/doglogs/modules/server_fps.lua
@@ -1,0 +1,11 @@
+-- Records the Server's FPS as a rate metric
+
+DogMetrics:NewMetric( {
+    name = "server.fps3",
+    unit = "frame",
+    interval = 1,
+    metricType = DogMetrics.MetricTypes.rate,
+    measureFunc = function()
+        return 1 / FrameTime()
+    end
+} )

--- a/lua/doglogs/modules/server_fps.lua
+++ b/lua/doglogs/modules/server_fps.lua
@@ -1,7 +1,7 @@
 -- Records the Server's FPS as a rate metric
 
 DogMetrics:NewMetric( {
-    name = "server.fps3",
+    name = "gameserver.fps",
     unit = "frame",
     interval = 1,
     metricType = DogMetrics.MetricTypes.rate,

--- a/lua/doglogs/modules/server_fps.lua
+++ b/lua/doglogs/modules/server_fps.lua
@@ -4,7 +4,7 @@ DogMetrics:NewMetric( {
     name = "gameserver.fps",
     unit = "frame",
     interval = 1,
-    metricType = DogMetrics.MetricTypes.rate,
+    metricType = DogMetrics.MetricTypes.Rate,
     measureFunc = function()
         return 1 / FrameTime()
     end

--- a/lua/doglogs/modules/server_fps.lua
+++ b/lua/doglogs/modules/server_fps.lua
@@ -1,11 +1,39 @@
 -- Records the Server's FPS as a rate metric
 
-DogMetrics:NewMetric( {
-    name = "gameserver.fps",
+local Deque = include( "doglogs/utils/deque.lua" )
+
+local tracker = DogMetrics:NewMetric( {
+    name = "cfc.server.fps",
     unit = "frame",
     interval = 1,
-    metricType = DogMetrics.MetricTypes.Rate,
-    measureFunc = function()
-        return 1 / FrameTime()
-    end
+    metricType = DogMetrics.MetricTypes.Rate
 } )
+
+local windowSize = 10
+local currentTotal = 0
+
+-- Prefill the queue
+local frameQueue = Deque() do
+    local targetFps = 1 / engine.TickInterval()
+    currentTotal = targetFps * windowSize
+
+    for _ = 1, windowSize do
+        frameQueue:Push( targetFps )
+    end
+end
+
+local i = 0
+hook.Add( "Think", "DogMetrics_ServerFPS", function()
+    local fps = 1 / FrameTime()
+
+    local oldestFps = frameQueue:Pop()
+    frameQueue:Push( fps )
+
+    currentTotal = currentTotal + fps - oldestFps
+
+    i = i + 1
+    if i >= windowSize then
+        tracker:AddPoint( currentTotal / windowSize )
+        i = 0
+    end
+end )

--- a/lua/doglogs/modules/server_fps.lua
+++ b/lua/doglogs/modules/server_fps.lua
@@ -18,7 +18,7 @@ local frameQueue = Deque() do
     currentTotal = targetFps * windowSize
 
     for _ = 1, windowSize do
-        frameQueue:Push( targetFps )
+        frameQueue.Push( targetFps )
     end
 end
 
@@ -26,8 +26,8 @@ local i = 0
 hook.Add( "Think", "DogMetrics_ServerFPS", function()
     local fps = 1 / FrameTime()
 
-    local oldestFps = frameQueue:Pop()
-    frameQueue:Push( fps )
+    local oldestFps = frameQueue.Pop()
+    frameQueue.Push( fps )
 
     currentTotal = currentTotal + fps - oldestFps
 

--- a/lua/doglogs/modules/server_lua_memory.lua
+++ b/lua/doglogs/modules/server_lua_memory.lua
@@ -1,0 +1,11 @@
+-- Records the server's Lua memory size
+
+DogMetrics:NewMetric( {
+    name = "cfc.server.luaMemory",
+    unit = "kilobyte",
+    interval = 1,
+    metricType = DogMetrics.MetricTypes.Count,
+    measureFunc = function()
+        return collectgarbage( "count" )
+    end
+} )

--- a/lua/doglogs/sv_init.lua
+++ b/lua/doglogs/sv_init.lua
@@ -1,9 +1,9 @@
--- Find all files in modules/ and include them
-
 DogLogs = {}
 function DogLogs.Log( str )
     print( str )
 end
+
+include( "metrics.lua" )
 
 local modulesPath = "doglogs/modules/"
 

--- a/lua/doglogs/utils/deque.lua
+++ b/lua/doglogs/utils/deque.lua
@@ -1,0 +1,38 @@
+local function Deque()
+    local Data = {}
+    local Queue = {}
+
+    local head = 1
+    local tail = 0
+    local size = 0
+
+    function Queue.Push( value )
+        tail = tail + 1
+        Data[tail] = value
+
+        size = size + 1
+    end
+
+    function Queue.Pop()
+        if head > tail then return nil end
+
+        local value = Data[head]
+        Data[head] = nil
+        head = head + 1
+        size = size - 1
+
+        return value
+    end
+
+    function Queue.IsEmpty()
+        return size == 0
+    end
+
+    function Queue.GetSize()
+        return size
+    end
+
+    return Queue
+end
+
+return Deque


### PR DESCRIPTION
Seems to work well in development. Tried to make it easy but still flexible.

One issue right now is I can't figure out how to set this denominator? It isn't documented in the API anywhere. The units also suck to work with:
![image](https://github.com/user-attachments/assets/5c376804-d04c-47da-b6b6-c9c1d781ee51)

When updating the units in the web UI, my browser sent this payload:
```
short_name    ""
orientation    "0"
integration    ""
unit_id    "164"
per_unit_id    "11"
metric_type    "count"
metric_name    "server.fps2"
interval    "1"
```

So it's the `unit_id` and `per_unit_id` that control those.. None of that is documented in the API and I have no idea where to find a list of those codes (maybe from one of the API GETs or something).

Anyway, all that's to say that we may need to do some minor massaging on the datadog UI - should just be once per metric, at worst.