### PR TITLE
Rework metrics

### DIFF
--- a/lua/doglogs/metrics/sv_init.lua
+++ b/lua/doglogs/metrics/sv_init.lua
@@ -136,7 +136,7 @@ function DogMetrics:GetReportPayload()
     local payload = { series = {} }
 
     for _, tracker in ipairs( self.trackers ) do
-        local trackerPayload = tracker:GetPayload()
+        local trackerPayload = tracker.GetPayload()
 
         if trackerPayload then
             table.insert( payload.series, trackerPayload )
@@ -149,7 +149,7 @@ end
 --- Clears all points from all trackers
 function DogMetrics:ClearTrackerPoints()
     for _, tracker in ipairs( self.trackers ) do
-        tracker:ClearPoints()
+        tracker.ClearPoints()
     end
 end
 

--- a/lua/doglogs/metrics/tracker.lua
+++ b/lua/doglogs/metrics/tracker.lua
@@ -1,0 +1,130 @@
+--- @class DogMetrics_NewTrackerParams
+--- @field name string The name of the metric
+--- @field unit string The unit of the metric (e.g., "ms", "bytes", etc.)
+--- @field interval number? The interval in seconds at which the metric should be reported (if omitted, as is the case in Count and Rates, the interal defaults to the reporting interval)
+--- @field metricType DogMetrics_MetricTypes The type of the metric
+--- @field hostname string The hostname of the server
+--- @field serviceName string The name of the service (e.g., "gmod", "serverName", "addonName")
+
+--- @class DogMetrics_Resource
+--- @field name string The name of the resource (e.g., "gmod", "serverName", "addonName")
+--- @field type string The type of the resource (e.g., "source", "host", "service")
+
+--- Creates a new metric tracker
+--- @param struct DogMetrics_NewTrackerParams The parameters for the new tracker
+return function( struct )
+    local name = assert( struct.name, "Metric name is required" )
+    local unit = assert( struct.unit, "Metric unit is required" )
+    local metricType = assert( struct.metricType, "Metric type is required" )
+    local interval = struct.interval
+
+    --- @type DogMetrics_Point[]
+    local points = {}
+
+    --- @type string[] A list of timer names for this tracker
+    local timers = {}
+
+    --- @class DogMetrics_TrackerPayload
+    local payload = {
+        --- @type number? The interval (in seconds) at which this metric should be reported (not used for Gauge types)
+        interval = interval,
+
+        --- @type string The name of the metric
+        metric = name,
+
+        --- @type DogMetrics_MetricTypes The type of the metric
+        type = metricType,
+
+        --- @type string The unit of the metric
+        unit = unit,
+
+        --- @type DogMetrics_Point[] The points collected for this metric
+        points = points,
+
+        --- @type DogMetrics_Resource[] The resources associated with this metric
+        resources = {
+            { name = "gmod", type = "source" },
+            { name = hostname:GetString(), type = "host" },
+            { name = serviceName:GetString(), type = "service" }
+        }
+    }
+
+    --- @class DogMetrics_Tracker
+    local tracker = {
+        --- @type DogMetrics_TrackerPayload The payload for the tracker
+        payload = payload,
+
+        --- @type string[] The name of the timers associated with this tracker
+        timers = timers,
+    }
+
+    --- Adds a point to the tracker's timeseries
+    --- @param value number The value to add to the timeseries
+    function tracker.AddPoint( value )
+        --- @class DogMetrics_Point
+        local point = {
+            --- @type number The timestamp of the point
+            timestamp = os.time(),
+
+            --- @type number The value of the point
+            value = value
+        }
+
+        table.insert( points, point )
+    end
+
+    --- Overwrite this function to prepare points immediately before reporting
+    --- (i.e. counts will add their current count/rates will report their current count)
+    function tracker.PreparePoints()
+    end
+
+    --- Prepares and returns the payload for the tracker
+    --- @return DogMetrics_TrackerPayload? payload The payload for the tracker, or nil if there are no points to report
+    function tracker.GetPayload()
+        tracker.PreparePoints()
+
+        -- Don't report if there are no points
+        if #points == 0 then return nil end
+
+        return payload
+    end
+
+    --- Clears all points from the tracker
+    function tracker.ClearPoints()
+        points = {}
+        payload.points = points
+    end
+
+    --- Starts a new timer for the tracker
+    --- This is a normal timer that will be automatically cleaned up if the measure function errors, or if tracker.err is called
+    --- @param timerName string The name of the timer
+    --- @param timerInterval number The interval in seconds at which the timer should run
+    --- @param func fun(): nil The function to call each time the timer runs
+    function tracker.Timer( timerName, timerInterval, func )
+        local time = SysTime()
+
+        timerName = "DogMetrics_Tracker_" .. name .. "_" .. timerName .. "_" .. time
+        table.insert( timers, timerName )
+
+        timer.Create( timerName, timerInterval, 0, function()
+            local success, err = pcall( func )
+            if not success then
+                tracker.err( "Timer '" .. name .. "' failed: " .. tostring( err ) )
+            end
+        end )
+    end
+
+    --- Report an error and remove the tracker from the list
+    --- @param message string The error message to report
+    function tracker.err( message )
+        for _, timerName in ipairs( tracker.timers ) do
+            timer.Remove( timerName )
+        end
+
+        DogMetrics:RemoveTracker( tracker )
+
+        error( "Error in metric '" .. name .. "': " .. message, 1 )
+    end
+
+    return tracker
+end

--- a/lua/doglogs/modules/metrics/ent_count.lua
+++ b/lua/doglogs/modules/metrics/ent_count.lua
@@ -1,13 +1,6 @@
-DogMetrics:NewMetric( {
-    name = "cfc.server.entCount.total",
-    unit = "entity",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return ents.GetCount()
-    end
-} )
-
+DogMetrics:NewGauge( "cfc.server.entCount.total", "entities", 5, function()
+    return ents.GetCount()
+end )
 
 --- @type Entity
 local entMeta = assert( FindMetaTable( "Entity" ) )
@@ -21,36 +14,16 @@ local ent_GetPhysicsObject = entMeta.GetPhysicsObject
 local interval = 10
 
 local npcCount = 0
-local NPCTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.entCount.npc",
-    unit = "npc",
-    interval = interval,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
+local NPCTracker = DogMetrics:NewGauge( "cfc.server.entCount.npc", "npcs" )
 
 local propPhysicsCount = 0
-local PropPhysicsTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.entCount.props.total",
-    unit = "prop",
-    interval = interval,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
+local PropPhysicsTracker = DogMetrics:NewGauge( "cfc.server.entCount.props.total", "props" )
 
 local unfrozenPropCount = 0
-local UnfrozenTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.entCount.props.unfrozen",
-    unit = "prop",
-    interval = interval,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
+local UnfrozenTracker = DogMetrics:NewGauge( "cfc.server.entCount.props.unfrozen", "prop" )
 
 local constraintCount = 0
-local ConstraintTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.entCount.constraint",
-    unit = "constraint",
-    interval = interval,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
+local ConstraintTracker = DogMetrics:NewGauge( "cfc.server.entCount.constraints", "constraints" )
 
 timer.Create( "DogMetrics_EntityCounter", interval, 0, function()
     npcCount = 0
@@ -79,8 +52,8 @@ timer.Create( "DogMetrics_EntityCounter", interval, 0, function()
         end
     end
 
-    NPCTracker:AddPoint( npcCount )
-    PropPhysicsTracker:AddPoint( propPhysicsCount )
-    UnfrozenTracker:AddPoint( unfrozenPropCount )
-    ConstraintTracker:AddPoint( constraintCount )
+    NPCTracker.AddPoint( npcCount )
+    PropPhysicsTracker.AddPoint( propPhysicsCount )
+    UnfrozenTracker.AddPoint( unfrozenPropCount )
+    ConstraintTracker.AddPoint( constraintCount )
 end )

--- a/lua/doglogs/modules/metrics/net_vars.lua
+++ b/lua/doglogs/modules/metrics/net_vars.lua
@@ -1,16 +1,10 @@
-DogMetrics:NewMetric( {
-    name = "cfc.server.netVars.total",
-    unit = "vars",
-    interval = 10,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        local netVarCount = 0
+DogMetrics:NewGauge( "cfc.server.netVars.count", "vars", 10, function()
+    local netVarCount = 0
 
-        local netVars = BuildNetworkedVarsTable()
-        for _, varTbl in pairs( netVars ) do
-            netVarCount = netVarCount + table.Count( varTbl )
-        end
-
-        return netVarCount
+    local netVars = BuildNetworkedVarsTable()
+    for _, varTbl in pairs( netVars ) do
+        netVarCount = netVarCount + table.Count( varTbl )
     end
-} )
+
+    return netVarCount
+end )

--- a/lua/doglogs/modules/metrics/player_count.lua
+++ b/lua/doglogs/modules/metrics/player_count.lua
@@ -1,40 +1,11 @@
-DogMetrics:NewMetric( {
-    name = "cfc.server.players.total",
-    unit = "player",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return #player.GetHumans()
-    end
-} )
+DogMetrics:NewGauge( "cfc.server.players.total", "players", 1, function()
+    return #player.GetHumans()
+end )
 
-local AFKTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.players.afk",
-    unit = "player",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
-
-local SentinelTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.players.sentinel",
-    unit = "player",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
-
-local ModeratorTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.players.moderator",
-    unit = "player",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
-
-local AdminTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.players.admin",
-    unit = "player",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
+local AFKTracker = DogMetrics:NewGauge( "cfc.server.players.afk", "players" )
+local SentinelTracker = DogMetrics:NewGauge( "cfc.server.players.sentinel", "players" )
+local ModeratorTracker = DogMetrics:NewGauge( "cfc.server.players.moderator", "players" )
+local AdminTracker = DogMetrics:NewGauge( "cfc.server.players.admin", "players" )
 
 local function isAdmin( ply )
     return ply:IsAdmin() or ply:IsSuperAdmin()
@@ -62,8 +33,8 @@ timer.Create( "DogMetrics_PlayerCountTracker", 5, 0, function()
         end
     end
 
-    AFKTracker:AddPoint( afkCount )
-    SentinelTracker:AddPoint( sentinelCount )
-    ModeratorTracker:AddPoint( moderatorCount )
-    AdminTracker:AddPoint( adminCount )
+    AFKTracker.AddPoint( afkCount )
+    SentinelTracker.AddPoint( sentinelCount )
+    ModeratorTracker.AddPoint( moderatorCount )
+    AdminTracker.AddPoint( adminCount )
 end )

--- a/lua/doglogs/modules/metrics/player_net.lua
+++ b/lua/doglogs/modules/metrics/player_net.lua
@@ -1,16 +1,5 @@
-local PingTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.ping.average",
-    unit = "milliseconds",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
-
-local LossTracker = DogMetrics:NewMetric( {
-    name = "cfc.server.packetLoss.average",
-    unit = "percent",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Gauge,
-} )
+local PingTracker = DogMetrics:NewGauge( "cfc.server.ping.average", "miliseconds" )
+local LossTracker = DogMetrics:NewGauge( "cfc.server.packetLoss.average", "percent" )
 
 timer.Create( "DogMetrics_PlayerNetPerformance", 1, 0, function()
     local totalPing = 0
@@ -30,8 +19,8 @@ timer.Create( "DogMetrics_PlayerNetPerformance", 1, 0, function()
     end
 
     local averagePing = plyCount > 0 and totalPing / plyCount or 0
-    PingTracker:AddPoint( averagePing )
+    PingTracker.AddPoint( averagePing )
 
     local averageLoss = plyCount > 0 and totalLoss / plyCount or 0
-    LossTracker:AddPoint( averageLoss )
+    LossTracker.AddPoint( averageLoss )
 end )

--- a/lua/doglogs/modules/metrics/precache.lua
+++ b/lua/doglogs/modules/metrics/precache.lua
@@ -2,48 +2,18 @@ if not stringtable then return end
 
 -- Models
 local modelPrecache = stringtable.FindTable( "modelprecache" )
-DogMetrics:NewMetric( {
-    name = "cfc.server.modelPrecache.size",
-    unit = "vars",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return modelPrecache:GetNumStrings()
-    end
-} )
-
--- Generic
-local genericPrecache = stringtable.FindTable( "genericprecache" )
-DogMetrics:NewMetric( {
-    name = "cfc.server.genericPrecache.size",
-    unit = "vars",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return genericPrecache:GetNumStrings()
-    end
-} )
+DogMetrics:NewGauge( "cfc.server.modelPrecache.size", "vars", 5, function()
+    return modelPrecache:GetNumStrings()
+end )
 
 -- Sound
 local soundPrecache = stringtable.FindTable( "soundprecache" )
-DogMetrics:NewMetric( {
-    name = "cfc.server.soundPrecache.size",
-    unit = "vars",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return soundPrecache:GetNumStrings()
-    end
-} )
+DogMetrics:NewGauge( "cfc.server.soundPrecache.size", "vars", 5, function()
+    return soundPrecache:GetNumStrings()
+end )
 
 -- Decal
 local decalPrecache = stringtable.FindTable( "decalprecache" )
-DogMetrics:NewMetric( {
-    name = "cfc.server.decalPrecache.size",
-    unit = "vars",
-    interval = 5,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return decalPrecache:GetNumStrings()
-    end
-} )
+DogMetrics:NewGauge( "cfc.server.decalPrecache.size", "vars", 5, function()
+    return decalPrecache:GetNumStrings()
+end )

--- a/lua/doglogs/modules/metrics/server_fps.lua
+++ b/lua/doglogs/modules/metrics/server_fps.lua
@@ -1,40 +1,4 @@
--- Records the Server's FPS as a rate metric
+local Tracker = DogMetrics:NewRate( "cfc.server.fps", "frame" )
+local Increment = Tracker.Increment
 
-local engine_AbsoluteFrameTime = engine.AbsoluteFrameTime
-local Deque = include( "doglogs/utils/deque.lua" )
-
-local Tracker = DogMetrics:NewMetric( {
-    name = "cfc.server.fps",
-    unit = "frame",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Rate
-} )
-
-local windowSize = 10
-local currentTotal = 0
-
--- Prefill the queue
-local queue = Deque() do
-    local targetFps = 1 / engine.TickInterval()
-    currentTotal = targetFps * windowSize
-
-    for _ = 1, windowSize do
-        queue.Push( targetFps )
-    end
-end
-
-local i = 0
-hook.Add( "Tick", "DogMetrics_ServerFPS", function()
-    local fps = 1 / engine_AbsoluteFrameTime()
-
-    local oldest = queue.Pop()
-    queue.Push( fps )
-
-    currentTotal = currentTotal + fps - oldest
-
-    i = i + 1
-    if i >= windowSize then
-        Tracker:AddPoint( currentTotal / windowSize )
-        i = 0
-    end
-end )
+hook.Add( "Tick", "DogMetrics_ServerFPS", Increment )

--- a/lua/doglogs/modules/metrics/server_lua_memory.lua
+++ b/lua/doglogs/modules/metrics/server_lua_memory.lua
@@ -1,11 +1,3 @@
--- Records the server's Lua memory size
-
-DogMetrics:NewMetric( {
-    name = "cfc.server.luaMemory",
-    unit = "kilobyte",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return collectgarbage( "count" )
-    end
-} )
+DogMetrics:NewGauge( "cfc.server.luaMemory", "kilobyte", 1, function()
+    return collectgarbage( "count" )
+end )

--- a/lua/doglogs/modules/metrics/session_time.lua
+++ b/lua/doglogs/modules/metrics/session_time.lua
@@ -1,11 +1,4 @@
 local startTime = os.time()
-
-DogMetrics:NewMetric( {
-    name = "cfc.server.sessionTime",
-    unit = "seconds",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = function()
-        return os.time() - startTime
-    end
-} )
+DogMetrics:NewGauge( "cfc.server.sessionTime", "seconds", 1, function()
+    return os.time() - startTime
+end )

--- a/lua/doglogs/modules/metrics/simulation_time.lua
+++ b/lua/doglogs/modules/metrics/simulation_time.lua
@@ -1,14 +1,7 @@
--- Records the PhysEnv's simulation time
-
 local physenv_GetLastSimulationTime = physenv.GetLastSimulationTime
 local Deque = include( "doglogs/utils/deque.lua" )
 
-local Tracker = DogMetrics:NewMetric( {
-    name = "cfc.server.physenv.simulationTime",
-    unit = "seconds",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Gauge
-} )
+local Tracker = DogMetrics:NewGauge( "cfc.server.physenv.simulationTime", "seconds" )
 
 local windowSize = 10
 local currentTotal = 0
@@ -34,7 +27,7 @@ hook.Add( "Tick", "DogMetrics_ServerSimulationTime", function()
 
     i = i + 1
     if i >= windowSize then
-        Tracker:AddPoint( currentTotal / windowSize )
+        Tracker.AddPoint( currentTotal / windowSize )
         i = 0
     end
 end )

--- a/lua/doglogs/modules/metrics/uptime.lua
+++ b/lua/doglogs/modules/metrics/uptime.lua
@@ -1,7 +1,1 @@
-DogMetrics:NewMetric( {
-    name = "cfc.server.uptime",
-    unit = "seconds",
-    interval = 1,
-    metricType = DogMetrics.MetricTypes.Gauge,
-    measureFunc = SysTime
-} )
+DogMetrics:NewGauge( "cfc.server.uptime", "seconds", 1, SysTime )


### PR DESCRIPTION
This changes up how metrics get reported. Should reconcile the difference between the reporting interval and the gathering interval - especially, for rates and counts, the reporting interval now harvests the trackers at report-time instead of expect that the trackers will self-report at a good time (keeps data intervals much more consistent)